### PR TITLE
Adiciona descrição dos mini-cursos

### DIFF
--- a/app/programacao.html
+++ b/app/programacao.html
@@ -8,7 +8,7 @@
     <!--[if IE]><meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'><![endif]-->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Grupo LinguÁgil">
-    <meta name="author" content="humans.txt">
+    <meta name="author" content="Otávio Santana" >
 
     <title>Grupo Linguágil | Programação</title>
 
@@ -103,10 +103,10 @@
                           <tbody>
                             <tr>
                               <td>8:00 às 12:00</td>
-                              <td>AngularJS: Um Framework para facilitar sua vida (o curso)<br />
+                              <td title="Angularjs é um framework javascript construido e mantido pelo grupo de engenheiros do Google, ele usa o HTML como uma "template engine" aliado a conceitos de Orientação a Objetos, testes, dentre outros, no intuito de fornecer uma solução completa para o cliente-side de sua aplicação. Além disso tem total compatibilidade com as bibliotecas javascript mais utilizadas, como jQuery. é um novo conceito para desenvolvimento de web apps client-site. Este curso vai mostrar através de exemplos práticos que é possível criar aplicações complexas com um código baseado em boas práticas, simples, coeso, performático e modularizado. Pré-requisitos: Noções básicas de HTML, CSS e Javascript;">AngularJS: Um Framework para facilitar sua vida (o curso)<br />
                                 Wilson Mendes
                               </td>
-                              <td>Aplicações Restful com Demoiselle 2.5<br />
+                              <td title="Criação de Aplicações Restful com Demoiselle 2.5">Aplicações Restful com Demoiselle 2.5<br />
                                 Marlon Carvalho<br />
                                 Luciano Brandão
                               </td>
@@ -118,7 +118,7 @@
                             </tr>
                             <tr>
                               <td>13:00 às 17:00</td>
-                              <td>AngularJS: Um Framework para facilitar sua vida (o curso)<br />
+                              <td title="Angularjs é um framework javascript construido e mantido pelo grupo de engenheiros do Google, ele usa o HTML como uma "template engine" aliado a conceitos de Orientação a Objetos, testes, dentre outros, no intuito de fornecer uma solução completa para o cliente-side de sua aplicação. Além disso tem total compatibilidade com as bibliotecas javascript mais utilizadas, como jQuery. é um novo conceito para desenvolvimento de web apps client-site. Este curso vai mostrar através de exemplos práticos que é possível criar aplicações complexas com um código baseado em boas práticas, simples, coeso, performático e modularizado. Pré-requisitos: Noções básicas de HTML, CSS e Javascript;">AngularJS: Um Framework para facilitar sua vida (o curso)<br />
                                 Wilson Mendes
                               </td>
                               <td>Scala: Programação funcional na JVM<br />
@@ -144,7 +144,7 @@
                               <td>Bem vindo ao mundo fantástico do Xamarin<br />
                                 Paulo Ortins
                               </td>
-                              <td>Lambdas, Streams, com Java8 e além!<br />
+                              <td title="Certamente com a versão do Java 8, além das melhorias de performances, tivemos diversas melhorias que tornaram a vida do desenvolvedor muito mais fácil, como Lambda e Streams conheça esses recursos e muitos outros que virão para compor o vigésimo ano da linguagem mais utilizada no mundo.">Lambdas, Streams, com Java8 e além!<br />
                                 Otávio Santana
                               </td>
                             </tr>
@@ -158,7 +158,7 @@
                               <td>Bem vindo ao mundo fantástico do Xamarin<br />
                                 Paulo Ortins
                               </td>
-                              <td>Lambdas, Streams, com Java8 e além!<br />
+                              <td title="Certamente com a versão do Java 8, além das melhorias de performances, tivemos diversas melhorias que tornaram a vida do desenvolvedor muito mais fácil, como Lambda e Streams conheça esses recursos e muitos outros que virão para compor o vigésimo ano da linguagem mais utilizada no mundo.">Lambdas, Streams, com Java8 e além!<br />
                                 Otávio Santana
                               </td>
                             </tr>
@@ -188,10 +188,10 @@
                           <tbody>
                             <tr>
                               <td>8:00 às 12:00</td>
-                              <td>Python para Zumbis<br />
+                              <td title=" Conheça esta importante linguagem de programação com a mão na massa e de uma maneira divertida. Um conteúdo aprovado por milhares de pessoas que já fizeram a versão completa do curso.">Python para Zumbis<br />
                                 Fernando Masanori
                               </td>
-                              <td>Let's talk about Domain-Driven Design (O curso)<br />
+                              <td title="Conceitos básicos sobre modelagem, conceitos básicos sobre DDD, linguagem ubíqua e o código, modelagem evolutiva e iterativa, aplicando boas práticas de Orientação a Objetos.">Let's talk about Domain-Driven Design (O curso)<br />
                                 Osnir Oliveira
                               </td>
                             </tr>
@@ -202,10 +202,10 @@
                             </tr>
                             <tr>
                               <td>13:00 às 17:00</td>
-                              <td>Python para Zumbis<br />
+                              <td title=" Conheça esta importante linguagem de programação com a mão na massa e de uma maneira divertida. Um conteúdo aprovado por milhares de pessoas que já fizeram a versão completa do curso.">Python para Zumbis<br />
                                 Fernando Masanori
                               </td>
-                              <td>Let's talk about Domain-Driven Design (O curso)<br />
+                              <td title="Conceitos básicos sobre modelagem, conceitos básicos sobre DDD, linguagem ubíqua e o código, modelagem evolutiva e iterativa, aplicando boas práticas de Orientação a Objetos.">Let's talk about Domain-Driven Design (O curso)<br />
                                 Osnir Oliveira
                               </td>
                             </tr>


### PR DESCRIPTION
Adiciona a descrição dos mini-cursos.
-  **Motivação:** Do modo atual [na página de programação](http://linguagil.com.br/programacao.html) não tenho descrição das atividades do mini-curso. Para isso teria que ir para inscrição, pouco intuitivo.
  A solução rápida é basicamente adicionar a tag `title` com essa informação.
